### PR TITLE
Update README with `Builder::default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ inter-event timing information. More concretely, given code like this:
 ```rust
 use tracing::*;
 use tracing_timing::{Builder, Histogram};
-let subscriber = Builder::from(|| Histogram::new_with_max(1_000_000, 2).unwrap()).build();
+let subscriber = Builder::default().build(|| Histogram::new_with_max(1_000_000, 2).unwrap());
 let dispatcher = Dispatch::new(subscriber);
 dispatcher::with_default(&dispatcher, || {
     trace_span!("request").in_scope(|| {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 ///
 /// This type implements the [builder pattern]. It lets you easily configure and construct a new
 /// [`TimingSubscriber`] subscriber. See the individual methods for details. To start, use
-/// [`Builder::from`]:
+/// [`Builder::default`]:
 ///
 /// ```rust
 /// use tracing_timing::{Builder, Histogram};


### PR DESCRIPTION
Hi, I noticed that the README was a little out of date with the new `Builder` interface.

I feel the maintenance pain, I've previously experimented with tools to turn your lib docs into the README but never found anything I was happy with.