### PR TITLE
Span close event

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
  - template: default.yml@templates
    parameters:
-     minrust: 1.39.0 # bind_by_move_pattern_guards
+     minrust: 1.47.0 # bitvec
      codecov_token: $(CODECOV_TOKEN_SECRET)
 
 resources:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,7 @@ where
     event_group: E,
     time: quanta::Clock,
     bubble_spans: bool,
+    span_close_events: bool,
 
     writers: ShardedLock<WriterState<S::Id, E::Id>>,
     reader: Mutex<ReaderState<S::Id, E::Id>>,

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -209,7 +209,7 @@ where
                     r @ Err(_) => r.unwrap(),
                 }
             };
-        };
+        }
 
         if 1 == unwinding_lock!(self.spans.read())[span_id_to_slab_idx(&span)]
             .refcount

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -216,7 +216,21 @@ where
             .fetch_sub(1, atomic::Ordering::AcqRel)
         {
             // span has ended!
-            // reclaim its id
+            if self.timing.span_close_events {
+                // record a span-end event
+                let inner = unwinding_lock!(self.spans.read());
+                if let Some(span_info) = inner.get(span_id_to_slab_idx(&span)) {
+                    let meta = span_info.meta;
+                    let fs = field::FieldSet::new(&["message"], meta.callsite());
+                    let fld = fs.iter().next().unwrap();
+                    let v = [(&fld, Some(&"close" as &dyn field::Value))];
+                    let vs = fs.value_set(&v);
+                    let e = Event::new_child_of(span.clone(), meta, &vs);
+                    self.event(&e);
+                }
+            }
+
+            // reclaim the span's id
             let mut inner = unwinding_lock!(self.spans.write());
             inner.remove(span_id_to_slab_idx(&span));
             // we _keep_ the entry in inner.recorders in place, since it may be used by other spans

--- a/tests/layer.rs
+++ b/tests/layer.rs
@@ -638,6 +638,8 @@ fn span_close_event() {
     std::thread::spawn(move || {
         dispatcher::with_default(&d2, || {
             trace_span!("foo").in_scope(|| {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                trace!("foo_start");
                 trace_span!("bar").in_scope(|| {
                     trace!("bar_end");
                     std::thread::sleep(std::time::Duration::from_millis(1));
@@ -655,12 +657,17 @@ fn span_close_event() {
         assert!(hs.contains_key("bar"));
 
         // foo membership
+        assert!(hs["foo"].contains_key("foo_start"));
         assert!(hs["foo"].contains_key("foo_end"));
         assert!(hs["foo"].contains_key("close"));
 
         // bar membership
         assert!(hs["bar"].contains_key("bar_end"));
         assert!(hs["bar"].contains_key("close"));
+
+        let foo_start = hs["foo"]["foo_start"].max();
+        let bar_end = hs["bar"]["bar_end"].max();
+        assert!(foo_start > bar_end);
 
         let foo_end = hs["foo"]["foo_end"].max();
         let bar_close = hs["bar"]["close"].max();

--- a/tests/layer.rs
+++ b/tests/layer.rs
@@ -628,6 +628,47 @@ fn nested_bubble() {
 }
 
 #[test]
+fn span_close_event() {
+    let s = Builder::default()
+        .span_close_events()
+        .layer(|| Histogram::new_with_max(200_000_000, 1).unwrap());
+    let sid = s.downcaster();
+    let d = Dispatch::new(s.with_subscriber(Registry::default()));
+    let d2 = d.clone();
+    std::thread::spawn(move || {
+        dispatcher::with_default(&d2, || {
+            trace_span!("foo").in_scope(|| {
+                trace_span!("bar").in_scope(|| {
+                    trace!("bar_end");
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                });
+                trace!("foo_end");
+            })
+        })
+    })
+    .join()
+    .unwrap();
+    sid.downcast(&d).unwrap().force_synchronize();
+    sid.downcast(&d).unwrap().with_histograms(|hs| {
+        assert_eq!(hs.len(), 2);
+        assert!(hs.contains_key("foo"));
+        assert!(hs.contains_key("bar"));
+
+        // foo membership
+        assert!(hs["foo"].contains_key("foo_end"));
+        assert!(hs["foo"].contains_key("close"));
+
+        // bar membership
+        assert!(hs["bar"].contains_key("bar_end"));
+        assert!(hs["bar"].contains_key("close"));
+
+        let foo_end = hs["foo"]["foo_end"].max();
+        let bar_close = hs["bar"]["close"].max();
+        assert!(bar_close > foo_end);
+    })
+}
+
+#[test]
 fn explicit_span_parent() {
     let s = Builder::default().layer(|| Histogram::new_with_max(200_000_000, 1).unwrap());
     let sid = s.downcaster();


### PR DESCRIPTION
tracing-subscriber has support for span-close events (https://docs.rs/tracing-subscriber/0.2.17/tracing_subscriber/fmt/struct.Layer.html#method.with_span_events), but these events aren't available to other layers.

For timing purposes, we already track the time from the start of the span, so this lets us track the time from the last event in a span to its close also. We can also get timing information about a span even if there are no events inside it.