### PR TITLE
Bump crossbeam and quanta dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ default = ["layer"]
 tracing-core = "0.1.2"
 hdrhistogram = "7"
 slab = "0.4"
-quanta = "0.3"
+quanta = "0.7"
 fxhash = "0.2"
-crossbeam = "0.7"
+crossbeam = "0.8"
 indexmap = "1.0"
 doc-comment = "0.3"
 tracing-subscriber = { version = "0.2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-timing"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2018"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 
@@ -36,8 +36,8 @@ tracing-subscriber = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 tracing = "0.1.2"
-rand = "0.7"
-rand_distr = "0.2.1"
+rand = "0.8"
+rand_distr = "0.4"
 
 [profile.release]
 debug = true

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -90,7 +90,7 @@ where
         let span = ctx.span(id).unwrap();
         span.extensions_mut().insert(SpanState {
             group,
-            last_event: atomic::AtomicU64::new(self.timing.time.now()),
+            last_event: atomic::AtomicU64::new(self.timing.time.raw()),
         });
     }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -121,7 +121,7 @@ where
             refcount: atomic::AtomicUsize::new(1),
             state: SpanState {
                 group: group.clone(),
-                last_event: atomic::AtomicU64::new(self.timing.time.now()),
+                last_event: atomic::AtomicU64::new(self.timing.time.raw()),
             },
         };
 


### PR DESCRIPTION
crossbeam 0.7 -> 0.8, quanta 0.3 -> 0.7

The quanta change should save a few cycles in scaling raw time values
once instead of twice.

Merging this should wait for https://github.com/jonhoo/tracing-timing/pull/12 so we can also set the default for close events.