### PR TITLE
Add Layer example

### DIFF
--- a/examples/layer.rs
+++ b/examples/layer.rs
@@ -20,6 +20,10 @@ fn main() {
     tracing::dispatcher::set_global_default(dispatch.clone()).unwrap();
 
     std::thread::spawn(move || {
+        info!(
+            "{:?}: Logging tracing-timing results",
+            std::thread::current().id()
+        );
         loop {
             // wait for first traces
             std::thread::sleep(std::time::Duration::from_secs(1));
@@ -47,11 +51,14 @@ fn main() {
     });
 
     std::thread::spawn(move || {
+        info!(
+            "{:?}: Emulating work and creating traces",
+            std::thread::current().id()
+        );
         use rand::prelude::*;
         let mut rng = thread_rng();
         let fast = Normal::<f64>::new(10_000_000.0, 5_000_000.0).unwrap();
         let slow = Normal::<f64>::new(50_000_000.0, 5_000_000.0).unwrap();
-        info!("Normal info");
         loop {
             let fast = std::time::Duration::from_nanos(fast.sample(&mut rng).max(0.0) as u64);
             let slow = std::time::Duration::from_nanos(slow.sample(&mut rng).max(0.0) as u64);

--- a/examples/layer.rs
+++ b/examples/layer.rs
@@ -1,0 +1,68 @@
+use rand_distr::Normal;
+use tracing::*;
+use tracing_subscriber::{fmt, layer::SubscriberExt, Layer};
+use tracing_timing::{Builder, Histogram};
+
+fn main() {
+    let timing_layer =
+        Builder::default().layer(|| Histogram::new_with_bounds(10_000, 1_000_000, 3).unwrap());
+    let downcaster = timing_layer.downcaster();
+
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            fmt::Layer::new()
+                .with_writer(std::io::stdout)
+                .with_filter(tracing::metadata::LevelFilter::INFO),
+        )
+        .with(timing_layer);
+
+    let dispatch = Dispatch::new(subscriber);
+    tracing::dispatcher::set_global_default(dispatch.clone()).unwrap();
+
+    std::thread::spawn(move || {
+        info!("Info from reporter thread");
+        loop {
+            downcaster
+                .downcast(&dispatch)
+                .unwrap()
+                .with_histograms(|hs| {
+                    for (span_group, hs) in &mut *hs {
+                        for (event_group, h) in hs {
+                            // make sure we see the latest samples:
+                            h.refresh();
+                            // log the median:
+                            info!(
+                                "[{}:{}] Median: {}ns, Min: {}ns, Max: {}ns",
+                                span_group,
+                                event_group,
+                                h.value_at_quantile(0.5),
+                                h.min(),
+                                h.max(),
+                            )
+                        }
+                    }
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                });
+        }
+    });
+
+    std::thread::spawn(move || {
+        use rand::prelude::*;
+        let mut rng = thread_rng();
+        let fast = Normal::<f64>::new(100_000.0, 50_000.0).unwrap();
+        let slow = Normal::<f64>::new(500_000.0, 50_000.0).unwrap();
+        info!("Normal info");
+        loop {
+            let fast = std::time::Duration::from_nanos(fast.sample(&mut rng).max(0.0) as u64);
+            let slow = std::time::Duration::from_nanos(slow.sample(&mut rng).max(0.0) as u64);
+            trace_span!("request").in_scope(|| {
+                std::thread::sleep(fast); // emulate some work
+                trace!("fast");
+                std::thread::sleep(slow); // emulate some more work
+                trace!("slow");
+            });
+        }
+    });
+
+    std::thread::sleep(std::time::Duration::from_secs(15));
+}

--- a/examples/layer.rs
+++ b/examples/layer.rs
@@ -32,10 +32,10 @@ fn main() {
                             // make sure we see the latest samples:
                             h.refresh();
                             info!(
-                                "[{}:{}] Median: {:.1}ms, Min: {:.1}ms, Max: {:.1}ms",
+                                "[{}:{}] Mean: {:.1}ms, Min: {:.1}ms, Max: {:.1}ms",
                                 span_group,
                                 event_group,
-                                h.value_at_quantile(0.5) as f32 / 1e6,
+                                h.mean() as f32 / 1e6,
                                 h.min() as f32 / 1e6,
                                 h.max() as f32 / 1e6,
                             )


### PR DESCRIPTION
Adds a short example that shows how to use the `TimingLayer` together with other layers in one shared subscriber.