### PR TITLE
Refactor examples and cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ doc-comment = "0.3"
 tracing-subscriber = { version = "0.3.8", optional = true }
 
 [dev-dependencies]
-tracing = "0.1.2"
+itertools = "0.14.0"
 rand = "0.9.1"
 rand_distr = "0.5.1"
+tracing = "0.1.2"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ tracing-subscriber = { version = "0.3.8", optional = true }
 
 [dev-dependencies]
 tracing = "0.1.2"
-rand = "0.8"
-rand_distr = "0.4"
+rand = "0.9.1"
+rand_distr = "0.5.1"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,9 @@ repository = "https://github.com/jonhoo/tracing-timing.git"
 keywords = ["perf", "tracing", "profiling"]
 categories = ["development-tools::profiling", "visualization"]
 
-[badges]
-azure-devops = { project = "jonhoo/jonhoo", pipeline = "tracing-timing", build = "13" }
-cirrus-ci = { repository = "jonhoo/tracing-timing" }
-codecov = { repository = "jonhoo/tracing-timing", branch = "master", service = "github" }
-maintenance = { status = "experimental" }
-
 [features]
-layer = ["tracing-subscriber"]
 default = ["layer"]
+layer = ["tracing-subscriber"]
 
 [dependencies]
 tracing-core = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Tracing-timing
+
 [![Crates.io](https://img.shields.io/crates/v/tracing-timing.svg)](https://crates.io/crates/tracing-timing)
 [![Documentation](https://docs.rs/tracing-timing/badge.svg)](https://docs.rs/tracing-timing/)
 [![Codecov](https://codecov.io/github/jonhoo/tracing-timing/coverage.svg?branch=master)](https://codecov.io/gh/jonhoo/tracing-timing)

--- a/examples/pretty.rs
+++ b/examples/pretty.rs
@@ -1,109 +1,74 @@
+use std::{thread, time::Duration};
+
+use hdrhistogram::SyncHistogram;
+use itertools::Itertools;
 use rand_distr::Normal;
-use tracing::*;
-use tracing_timing::{Builder, Histogram};
+use tracing::{dispatcher, trace, trace_span, Dispatch};
+use tracing_timing::{Builder, Histogram, TimingSubscriber};
 
 fn main() {
-    let s = Builder::default().build(|| Histogram::new_with_bounds(10_000, 1_000_000, 3).unwrap());
-    let sid = s.downcaster();
+    let subscriber =
+        Builder::default().build(|| Histogram::new_with_bounds(10_000, 1_000_000, 3).unwrap());
+    let dispatch = Dispatch::new(subscriber);
 
-    let d = Dispatch::new(s);
-    let d2 = d.clone();
-    std::thread::spawn(move || {
+    emulate_work(dispatch.clone());
+
+    let subscriber = dispatch.downcast_ref::<TimingSubscriber>().unwrap();
+    subscriber.with_histograms(|histograms_by_span| {
+        let request_histograms = histograms_by_span.get_mut("request").unwrap();
+
+        let fast = &mut request_histograms["fast"];
+        fast.refresh();
+        println!("fast:");
+        print_histogram(fast);
+
+        let slow = &mut request_histograms["slow"];
+        slow.refresh();
+        println!("\nslow:");
+        print_histogram(slow);
+    });
+}
+
+fn emulate_work(dispatch: Dispatch) {
+    thread::spawn(move || {
         use rand::prelude::*;
         let mut rng = rand::rng();
         let fast = Normal::<f64>::new(100_000.0, 50_000.0).unwrap();
         let slow = Normal::<f64>::new(500_000.0, 50_000.0).unwrap();
-        dispatcher::with_default(&d2, || loop {
-            let fast = std::time::Duration::from_nanos(fast.sample(&mut rng).max(0.0) as u64);
-            let slow = std::time::Duration::from_nanos(slow.sample(&mut rng).max(0.0) as u64);
+        dispatcher::with_default(&dispatch, || loop {
+            let fast = Duration::from_nanos(fast.sample(&mut rng).max(0.0) as u64);
+            let slow = Duration::from_nanos(slow.sample(&mut rng).max(0.0) as u64);
             trace_span!("request").in_scope(|| {
-                std::thread::sleep(fast); // emulate some work
+                thread::sleep(fast); // emulate some work
                 trace!("fast");
-                std::thread::sleep(slow); // emulate some more work
+                thread::sleep(slow); // emulate some more work
                 trace!("slow");
             });
         })
     });
-    std::thread::sleep(std::time::Duration::from_secs(15));
-
-    sid.downcast(&d).unwrap().with_histograms(|hs| {
-        assert_eq!(hs.len(), 1);
-        let hs = &mut hs.get_mut("request").unwrap();
-        assert_eq!(hs.len(), 2);
-
-        hs.get_mut("fast").unwrap().refresh();
-        hs.get_mut("slow").unwrap().refresh();
-
-        println!("fast:");
-        let h = &hs["fast"];
-        println!(
-            "mean: {:.1}µs, p50: {}µs, p90: {}µs, p99: {}µs, p999: {}µs, max: {}µs",
-            h.mean() / 1000.0,
-            h.value_at_quantile(0.5) / 1_000,
-            h.value_at_quantile(0.9) / 1_000,
-            h.value_at_quantile(0.99) / 1_000,
-            h.value_at_quantile(0.999) / 1_000,
-            h.max() / 1_000,
-        );
-        for v in break_once(
-            h.iter_linear(25_000).skip_while(|v| v.quantile() < 0.01),
-            |v| v.quantile() > 0.95,
-        ) {
-            println!(
-                "{:4}µs | {:40} | {:4.1}th %-ile",
-                (v.value_iterated_to() + 1) / 1_000,
-                "*".repeat(
-                    (v.count_since_last_iteration() as f64 * 40.0 / h.len() as f64).ceil() as usize
-                ),
-                v.percentile(),
-            );
-        }
-
-        println!("\nslow:");
-        let h = &hs["slow"];
-        println!(
-            "mean: {:.1}µs, p50: {}µs, p90: {}µs, p99: {}µs, p999: {}µs, max: {}µs",
-            h.mean() / 1000.0,
-            h.value_at_quantile(0.5) / 1_000,
-            h.value_at_quantile(0.9) / 1_000,
-            h.value_at_quantile(0.99) / 1_000,
-            h.value_at_quantile(0.999) / 1_000,
-            h.max() / 1_000,
-        );
-        for v in break_once(
-            h.iter_linear(25_000).skip_while(|v| v.quantile() < 0.01),
-            |v| v.quantile() > 0.95,
-        ) {
-            println!(
-                "{:4}µs | {:40} | {:4.1}th %-ile",
-                (v.value_iterated_to() + 1) / 1_000,
-                "*".repeat(
-                    (v.count_since_last_iteration() as f64 * 40.0 / h.len() as f64).ceil() as usize
-                ),
-                v.percentile(),
-            );
-        }
-    });
+    thread::sleep(Duration::from_secs(5));
 }
 
-// until we have https://github.com/rust-lang/rust/issues/62208
-fn break_once<I, F>(it: I, mut f: F) -> impl Iterator<Item = I::Item>
-where
-    I: IntoIterator,
-    F: FnMut(&I::Item) -> bool,
-{
-    let mut got_true = false;
-    it.into_iter().take_while(move |i| {
-        if got_true {
-            // we've already yielded when f was true
-            return false;
-        }
-        if f(i) {
-            // this must be the first time f returns true
-            // we should yield i, and then no more
-            got_true = true;
-        }
-        // f returned false, so we should keep yielding
-        true
-    })
+fn print_histogram(histogram: &SyncHistogram<u64>) {
+    println!(
+        "count: {}, mean: {:.1}µs, p50: {}µs, p90: {}µs, p99: {}µs, p999: {}µs, max: {}µs",
+        histogram.len(),
+        histogram.mean() / 1000.0,
+        histogram.value_at_quantile(0.5) / 1_000,
+        histogram.value_at_quantile(0.9) / 1_000,
+        histogram.value_at_quantile(0.99) / 1_000,
+        histogram.value_at_quantile(0.999) / 1_000,
+        histogram.max() / 1_000,
+    );
+    for value in histogram
+        .iter_linear(25_000)
+        .skip_while(|v| v.quantile() < 0.01)
+        .take_while_inclusive(|v| v.quantile() <= 0.95)
+    {
+        let bucket = (value.value_iterated_to() + 1) / 1_000;
+        let count = value.count_since_last_iteration() as f64 * 40.0 / histogram.len() as f64;
+        let stars = "*".repeat(count.ceil() as usize);
+        let percentile = value.percentile();
+        println!("{bucket:4}µs | {stars:40} | {percentile:4.1}th %-ile",);
+    }
 }

--- a/examples/pretty.rs
+++ b/examples/pretty.rs
@@ -10,7 +10,7 @@ fn main() {
     let d2 = d.clone();
     std::thread::spawn(move || {
         use rand::prelude::*;
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         let fast = Normal::<f64>::new(100_000.0, 50_000.0).unwrap();
         let slow = Normal::<f64>::new(500_000.0, 50_000.0).unwrap();
         dispatcher::with_default(&d2, || loop {

--- a/examples/profile.rs
+++ b/examples/profile.rs
@@ -16,7 +16,7 @@ fn main() {
     let mut r_trace = trace.recorder();
     std::thread::spawn(move || {
         use rand::prelude::*;
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         let fast = Normal::<f64>::new(100_000.0, 50_000.0).unwrap();
         let slow = Normal::<f64>::new(500_000.0, 50_000.0).unwrap();
         let clock = quanta::Clock::new();

--- a/examples/profile.rs
+++ b/examples/profile.rs
@@ -1,160 +1,94 @@
+use std::{thread, time::Duration};
+
+use hdrhistogram::{sync::Recorder, SyncHistogram};
+use itertools::Itertools;
+use quanta::Clock;
 use rand_distr::Normal;
-use tracing::*;
-use tracing_timing::{Builder, Histogram};
+use tracing::{dispatcher, trace, trace_span, Dispatch};
+use tracing_timing::{group::ByName, Builder, Histogram};
 
 fn main() {
-    let s = Builder::default()
-        .events(tracing_timing::group::ByName)
+    let subscriber = Builder::default()
+        .events(ByName)
         .build(|| Histogram::new_with_max(1_000_000, 2).unwrap());
-    let sid = s.downcaster();
+    let downcaster = subscriber.downcaster();
+    let dispatch = Dispatch::new(subscriber);
 
-    let d = Dispatch::new(s);
-    let d2 = d.clone();
-    let mut trace = Histogram::<u64>::new_with_bounds(100, 8_000, 3)
+    let mut trace = Histogram::new_with_bounds(100, 8_000, 3)
         .unwrap()
         .into_sync();
-    let mut r_trace = trace.recorder();
-    std::thread::spawn(move || {
-        use rand::prelude::*;
-        let mut rng = rand::rng();
-        let fast = Normal::<f64>::new(100_000.0, 50_000.0).unwrap();
-        let slow = Normal::<f64>::new(500_000.0, 50_000.0).unwrap();
-        let clock = quanta::Clock::new();
-        dispatcher::with_default(&d2, || loop {
-            let fast = std::time::Duration::from_nanos(fast.sample(&mut rng).max(0.0) as u64);
-            let slow = std::time::Duration::from_nanos(slow.sample(&mut rng).max(0.0) as u64);
-            trace_span!("request").in_scope(|| {
-                std::thread::sleep(fast);
-                let a = clock.start();
-                trace!("fast");
-                let b = clock.end();
-                r_trace.saturating_record(b - a);
-                std::thread::sleep(slow);
-                let a = clock.start();
-                trace!("slow");
-                let b = clock.end();
-                r_trace.saturating_record(b - a);
-            });
-        })
-    });
-    std::thread::sleep(std::time::Duration::from_secs(15));
+
+    emulate_work(dispatch.clone(), trace.recorder());
 
     // get trace info first, because refresh in with_histograms will slow down record in trace!
     trace.refresh();
 
-    sid.downcast(&d).unwrap().with_histograms(|hs| {
-        assert_eq!(hs.len(), 1);
-        let hs = &mut hs.get_mut("request").unwrap();
-        assert_eq!(hs.len(), 2);
-
-        hs.get_mut("event examples/profile.rs:29")
-            .unwrap()
-            .refresh();
-        hs.get_mut("event examples/profile.rs:34")
-            .unwrap()
-            .refresh();
+    let subscriber = downcaster.downcast(&dispatch).unwrap();
+    subscriber.with_histograms(|histograms_by_span| {
+        let request_histograms = histograms_by_span.get_mut("request").unwrap();
 
         println!("fast:");
-        let h = &hs["event examples/profile.rs:29"];
-        println!(
-            "mean: {:.1}µs, p50: {}µs, p90: {}µs, p99: {}µs, p999: {}µs, max: {}µs",
-            h.mean() / 1000.0,
-            h.value_at_quantile(0.5) / 1_000,
-            h.value_at_quantile(0.9) / 1_000,
-            h.value_at_quantile(0.99) / 1_000,
-            h.value_at_quantile(0.999) / 1_000,
-            h.max() / 1_000,
-        );
-        for v in break_once(
-            h.iter_linear(25_000).skip_while(|v| v.quantile() < 0.01),
-            |v| v.quantile() > 0.95,
-        ) {
-            println!(
-                "{:4}µs | {:40} | {:4.1}th %-ile",
-                (v.value_iterated_to() + 1) / 1_000,
-                "*".repeat(
-                    (v.count_since_last_iteration() as f64 * 40.0 / h.len() as f64).ceil() as usize
-                ),
-                v.percentile(),
-            );
-        }
+        let fast = &mut request_histograms["event examples/profile.rs:58"];
+        fast.refresh();
+        print_histogram(fast);
 
         println!("\nslow:");
-        let h = &hs["event examples/profile.rs:34"];
-        println!(
-            "mean: {:.1}µs, p50: {}µs, p90: {}µs, p99: {}µs, p999: {}µs, max: {}µs",
-            h.mean() / 1000.0,
-            h.value_at_quantile(0.5) / 1_000,
-            h.value_at_quantile(0.9) / 1_000,
-            h.value_at_quantile(0.99) / 1_000,
-            h.value_at_quantile(0.999) / 1_000,
-            h.max() / 1_000,
-        );
-        for v in break_once(
-            h.iter_linear(25_000).skip_while(|v| v.quantile() < 0.01),
-            |v| v.quantile() > 0.95,
-        ) {
-            println!(
-                "{:4}µs | {:40} | {:4.1}th %-ile",
-                (v.value_iterated_to() + 1) / 1_000,
-                "*".repeat(
-                    (v.count_since_last_iteration() as f64 * 40.0 / h.len() as f64).ceil() as usize
-                ),
-                v.percentile(),
-            );
-        }
+        let slow = &mut request_histograms["event examples/profile.rs:63"];
+        slow.refresh();
+        print_histogram(slow);
     });
 
     println!("\ntrace!:");
+    print_histogram(&trace);
+}
+
+fn emulate_work(dispatch: Dispatch, mut recorder: Recorder<u64>) {
+    thread::spawn(move || {
+        use rand::prelude::*;
+        let mut rng = rand::rng();
+        let fast = Normal::<f64>::new(100_000.0, 50_000.0).unwrap();
+        let slow = Normal::<f64>::new(500_000.0, 50_000.0).unwrap();
+        let clock = Clock::new();
+        dispatcher::with_default(&dispatch, || loop {
+            let fast = Duration::from_nanos(fast.sample(&mut rng).max(0.0) as u64);
+            let slow = Duration::from_nanos(slow.sample(&mut rng).max(0.0) as u64);
+            trace_span!("request").in_scope(|| {
+                thread::sleep(fast);
+                let a = clock.start();
+                trace!("fast");
+                let b = clock.end();
+                recorder.saturating_record(b - a);
+                thread::sleep(slow);
+                let a = clock.start();
+                trace!("slow");
+                let b = clock.end();
+                recorder.saturating_record(b - a);
+            });
+        })
+    });
+    thread::sleep(Duration::from_secs(5));
+}
+
+fn print_histogram(histogram: &SyncHistogram<u64>) {
     println!(
-        "mean: {:.1}µs, p50: {:.1}µs, p90: {:.1}µs, p99: {:.1}µs, p999: {:.1}µs, max: {:.1}µs",
-        trace.mean() / 1000.0,
-        trace.value_at_quantile(0.5) as f64 / 1000.0,
-        trace.value_at_quantile(0.9) as f64 / 1000.0,
-        trace.value_at_quantile(0.99) as f64 / 1000.0,
-        trace.value_at_quantile(0.999) as f64 / 1000.0,
-        trace.max() as f64 / 1000.0,
+        "count: {}, mean: {:.1}µs, p50: {}µs, p90: {}µs, p99: {}µs, p999: {}µs, max: {}µs",
+        histogram.len(),
+        histogram.mean() / 1000.0,
+        histogram.value_at_quantile(0.5) / 1_000,
+        histogram.value_at_quantile(0.9) / 1_000,
+        histogram.value_at_quantile(0.99) / 1_000,
+        histogram.value_at_quantile(0.999) / 1_000,
+        histogram.max() / 1_000,
     );
-    for v in break_once(trace.iter_linear(500), |v| v.quantile() > 0.95) {
-        println!(
-            "{:4.1}µs | {:40} | {:4.1}th %-ile",
-            (v.value_iterated_to() + 1) as f64 / 1000.0,
-            "*".repeat(
-                (v.count_since_last_iteration() as f64 * 40.0 / trace.len() as f64).ceil() as usize
-            ),
-            v.percentile()
-        );
-    }
-}
-
-// until we have https://github.com/rust-lang/rust/issues/62208
-fn break_once<I, F>(it: I, mut f: F) -> impl Iterator<Item = I::Item>
-where
-    I: IntoIterator,
-    F: FnMut(&I::Item) -> bool,
-{
-    let mut got_true = false;
-    it.into_iter().take_while(move |i| {
-        if got_true {
-            // we've already yielded when f was true
-            return false;
-        }
-        if f(i) {
-            // this must be the first time f returns true
-            // we should yield i, and then no more
-            got_true = true;
-        }
-        // f returned false, so we should keep yielding
-        true
-    })
-}
-
-#[cfg(test)]
-mod botest {
-    use super::break_once;
-    #[test]
-    fn bo1() {
-        let xs = break_once(vec![1, 2, 3, 4, 3, 2, 1], |&v| v > 3).collect::<Vec<_>>();
-        assert_eq!(xs, vec![1, 2, 3, 4]);
+    for value in histogram
+        .iter_linear(25_000)
+        .skip_while(|v| v.quantile() < 0.01)
+        .take_while_inclusive(|v| v.quantile() <= 0.95)
+    {
+        let bucket = (value.value_iterated_to() + 1) / 1_000;
+        let count = value.count_since_last_iteration() as f64 * 40.0 / histogram.len() as f64;
+        let stars = "*".repeat(count.ceil() as usize);
+        let percentile = value.percentile();
+        println!("{bucket:4}µs | {stars:40} | {percentile:4.1}th %-ile",);
     }
 }


### PR DESCRIPTION
This is a pure refactor PR that's purpose is just to make the examples simpler to understand

- **Add title to readme to satisfy markdown-lint**
- **Remove obselete badges section from Cargo.toml**
- **Bump rand and rand_distr versions for examples**
- **Simplify examples**
    - Replace break_once with take_while_inclusive from itertools
    - Simplify the repeated histogram printing code
    - Remove downcaster from pretty example
    - Name variables with more meaningful names
    - Reduce function lengths to improve readability